### PR TITLE
Update to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ repositories {
     mavenLocal()
     maven { name="BuildCraft"; url="https://mod-buildcraft.com/maven" }
     maven { url "https://maven.shedaniel.me/" }
-    maven { url "https://kneelawk.com/maven" }
 }
 
 archivesBaseName = "SimplePipes"

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ repositories {
     mavenLocal()
     maven { name="BuildCraft"; url="https://mod-buildcraft.com/maven" }
     maven { url "https://maven.shedaniel.me/" }
+    maven { url "https://kneelawk.com/maven" }
 }
 
 archivesBaseName = "SimplePipes"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
 }
 
 apply plugin: 'maven-publish' // for uploading to a maven repo
@@ -14,9 +14,9 @@ repositories {
 }
 
 archivesBaseName = "SimplePipes"
-version = "0.7.2"
+version = "0.8.0"
 
-minecraft {
+loom {
 }
 
 configurations {
@@ -24,12 +24,12 @@ configurations {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.18.2"
-    mappings "net.fabricmc:yarn:1.18.2+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.13.3"
+    minecraft "com.mojang:minecraft:1.19"
+    mappings "net.fabricmc:yarn:1.19+build.4:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.6"
 
     //Fabric api
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.47.8+1.18.2"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.57.0+1.19"
 
     // Silk API
     // modCompile "io.github.prospector.silk:SilkAPI:1.2.3-38"

--- a/build.gradle
+++ b/build.gradle
@@ -61,13 +61,7 @@ tasks.withType(JavaCompile) {
     it.options.release = 17
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
+java.withSourcesJar()
 
 publishing {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     // REI
     modCompileOnly "me.shedaniel:RoughlyEnoughItems-api:$rei_version"
     modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
-    modRuntime "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
+    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
 
     // Misc
     implementation "com.google.code.findbugs:jsr305:3.0.1"

--- a/extra_jar_def.gradle
+++ b/extra_jar_def.gradle
@@ -134,6 +134,9 @@ generateJar("items", itemsReq, [], false, [], ["core"]);
 // 2019/09/26 AlexIIL: Add a new user variable "extra_jar_def__fabric_mod_json_replacements", for replacing additional strings in fabric.mod.json
 // 2019/12/20 AlexIIL: Fix including all versions of the jars (including old versions if "gradle clean" hasn't been run)
 // 2020/01/23 AlexIIL: Add "fat" jars and the option for optimised compression.
+// 2020/02/22 AlexIIL: Added better error handling when generating fabric.mod.json files.
+// 2021/06/05 AlexIIL: Fixed a few missing task dependencies in gradle 7.
+// 2022/06/23 AlexIIL: Changed input jar (for nested jar extractions) to use remapJar directly, rather than just "jar"
 
 // ==========================================================
 // User config - change both of these on a per-project basis
@@ -181,7 +184,7 @@ ext.extra_jar_def__decompress_external_included = false;
 // Internals - don't touch this!
 // ==============================
 
-ext.extra_jar_def__jarFile = zipTree(jar.archivePath)
+ext.extra_jar_def__jarFile = zipTree(remapJar.archivePath)
 ext.extra_jar_def__modulesDir = new File(System.getenv("LIBS_DIR") ?: "$projectDir/build/libs/", version)
 ext.extra_jar_def__taken = new HashSet<>();
 ext.extra_jar_def__includedJarTasks = new HashSet<String>();
@@ -227,7 +230,7 @@ def getExpandedJarContentsFolder(String name) {
 }
 
 ext.extra_jar_def__unzippedSourceJar = new File("$projectDir/build/processing/tasks/unzipped_src_jar/unzip")
-task unzipSourcesJar(type: Copy, dependsOn: sourcesJar) {
+task unzipSourcesJar(type: Copy, dependsOn: remapSourcesJar) {
     from (zipTree(sourcesJar.archivePath)) {
         include "**"
     }
@@ -274,6 +277,9 @@ def writeFabricModJsonFile(String key, List<String> addedJars, boolean fat) {
     }
 
     def diff = source.remove("__buildscript_diff")[key];
+    if (diff == null) {
+        throw new Error("Missing buildscript diff for '" + key + "' in fabric.mod.json!");
+    }
     transformJson(source, diff);
 
     if (!addedJars.isEmpty()) {
@@ -303,6 +309,7 @@ task extractAllNestedJars(type: Copy, dependsOn: tasks["remapJar"]) {
         include "META-INF/jars/*.jar"
     }
     into "$projectDir/build/processing/included_jars/"
+    outputs.upToDateWhen { false }
 }
 
 def readAllBytes(InputStream is) throws IOException {
@@ -459,7 +466,7 @@ def generateJarInternal(
         }
     }
 
-    task("submod_" + key + "Jar", type: Jar, dependsOn: "writeFabricModJson_" + key) {
+    task("submod_" + key + "Jar", type: Jar, dependsOn: ["writeFabricModJson_" + key, "remapJar"]) {
 
         baseName = "$mainName-$key";
         destinationDir = extra_jar_def__modulesDir;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# Gradle keeps running out of heap space
+org.gradle.jvmargs=-Xmx1G
+
 libblockattributes_version=0.10.2
 libnetworkstack_version=0.6.0
 libmultipart_version=0.7.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle keeps running out of heap space
 org.gradle.jvmargs=-Xmx1G
 
-libblockattributes_version=0.10.2
-libnetworkstack_version=0.6.0
-libmultipart_version=0.7.2
-rei_version=6.0.268-alpha
+libblockattributes_version=0.11.0-pre.1.1
+libnetworkstack_version=0.7.0
+libmultipart_version=0.8.0-pre.1.2
+rei_version=9.1.500

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle keeps running out of heap space
 org.gradle.jvmargs=-Xmx1G
 
-libblockattributes_version=0.11.0-pre.1
+libblockattributes_version=0.11.0-pre.1.3+kneelawk
 libnetworkstack_version=0.7.1-pre.0.3+kneelawk
 libmultipart_version=0.8.0-pre.1.5+kneelawk
 rei_version=9.1.500

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle keeps running out of heap space
 org.gradle.jvmargs=-Xmx1G
 
-libblockattributes_version=0.11.0-pre.1.3+kneelawk
-libnetworkstack_version=0.7.1-pre.0.3+kneelawk
-libmultipart_version=0.8.0-pre.1.5+kneelawk
+libblockattributes_version=0.11.1
+libnetworkstack_version=0.7.1
+libmultipart_version=0.8.0
 rei_version=9.1.500

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 org.gradle.jvmargs=-Xmx1G
 
 libblockattributes_version=0.11.0-pre.1
-libnetworkstack_version=0.7.0
-libmultipart_version=0.8.0-pre.1
+libnetworkstack_version=0.7.1-pre.0.3+kneelawk
+libmultipart_version=0.8.0-pre.1.5+kneelawk
 rei_version=9.1.500

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle keeps running out of heap space
 org.gradle.jvmargs=-Xmx1G
 
-libblockattributes_version=0.11.0-pre.1.1
+libblockattributes_version=0.11.0-pre.1
 libnetworkstack_version=0.7.0
-libmultipart_version=0.8.0-pre.1.2
+libmultipart_version=0.8.0-pre.1
 rei_version=9.1.500

--- a/src/main/java/alexiil/mc/mod/pipes/SimplePipesClient.java
+++ b/src/main/java/alexiil/mc/mod/pipes/SimplePipesClient.java
@@ -7,10 +7,10 @@ package alexiil.mc.mod.pipes;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
-import net.fabricmc.fabric.api.client.rendereregistry.v1.BlockEntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;
 import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback;
-import net.fabricmc.fabric.api.event.client.ClientTickCallback;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.entity.BlockEntityType;
@@ -84,9 +84,7 @@ public class SimplePipesClient implements ClientModInitializer {
         });
         SimplePipeScreens.load();
         // RenderMatrixType.FROM_WORLD_ORIGIN.addRenderer(ItemPlacemenentGhostRenderer::render);
-        ClientTickCallback.EVENT.register(mc -> {
-            ItemPlacemenentGhostRenderer.clientTick();
-        });
+        ClientTickEvents.END_CLIENT_TICK.register(client -> ItemPlacemenentGhostRenderer.clientTick());
     }
 
     private static void setCutoutLayer(Block block) {
@@ -94,11 +92,11 @@ public class SimplePipesClient implements ClientModInitializer {
     }
 
     private static <T extends TilePipe> void registerItemPipeRender(BlockEntityType<T> type) {
-        BlockEntityRendererRegistry.INSTANCE.register(type, PipeItemTileRenderer::new);
+        BlockEntityRendererRegistry.register(type, PipeItemTileRenderer::new);
     }
 
     private static <T extends TilePipe> void registerFluidPipeRender(BlockEntityType<T> type) {
-        BlockEntityRendererRegistry.INSTANCE.register(type, PipeFluidTileRenderer::new);
+        BlockEntityRendererRegistry.register(type, PipeFluidTileRenderer::new);
     }
 
     private void registerSprites(SpriteAtlasTexture atlasTexture, ClientSpriteRegistryCallback.Registry registry) {

--- a/src/main/java/alexiil/mc/mod/pipes/blocks/BlockPipeSorter.java
+++ b/src/main/java/alexiil/mc/mod/pipes/blocks/BlockPipeSorter.java
@@ -5,7 +5,8 @@
  */
 package alexiil.mc.mod.pipes.blocks;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import alexiil.mc.mod.pipes.container.ContainerPipeSorter;
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -16,7 +17,6 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 import alexiil.mc.mod.pipes.pipe.PipeSpDef;
 
 public abstract class BlockPipeSorter extends BlockPipe {
@@ -31,12 +31,11 @@ public abstract class BlockPipeSorter extends BlockPipe {
     ) {
         BlockEntity be = world.getBlockEntity(pos);
 
-        if (be instanceof TilePipeItemDiamond) {
+        if (be instanceof TilePipeItemDiamond tile) {
             if (!world.isClient) {
-                ContainerProviderRegistry.INSTANCE
-                    .openContainer(SimplePipeContainers.PIPE_DIAMOND_ITEM, player, (buffer) -> {
-                        buffer.writeBlockPos(pos);
-                    });
+                player.openHandledScreen(new SimplePipeContainerFactory(getName(),
+                        (syncId, inv, player1) -> new ContainerPipeSorter(syncId, player1, tile),
+                        (player1, buf) -> buf.writeBlockPos(pos)));
             }
             return ActionResult.SUCCESS;
         }

--- a/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerFluidContains.java
+++ b/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerFluidContains.java
@@ -1,6 +1,7 @@
 package alexiil.mc.mod.pipes.blocks;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import alexiil.mc.mod.pipes.container.ContainerTriggerFluidContains;
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -11,8 +12,6 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 
 public class BlockTriggerFluidContains extends BlockTriggerFluidInv {
 
@@ -31,12 +30,11 @@ public class BlockTriggerFluidContains extends BlockTriggerFluidInv {
     ) {
         BlockEntity be = world.getBlockEntity(pos);
 
-        if (be instanceof TileTriggerFluidContains) {
+        if (be instanceof TileTriggerFluidContains tile) {
             if (!world.isClient) {
-                ContainerProviderRegistry.INSTANCE
-                    .openContainer(SimplePipeContainers.TRIGGER_FLUID_INV_CONTAINS, player, (buffer) -> {
-                        buffer.writeBlockPos(pos);
-                    });
+                player.openHandledScreen(new SimplePipeContainerFactory(getName(),
+                        (syncId, inv, player1) -> new ContainerTriggerFluidContains(syncId, player1, tile),
+                        (player1, buf) -> buf.writeBlockPos(pos)));
             }
             return ActionResult.SUCCESS;
         }

--- a/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerFluidSpace.java
+++ b/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerFluidSpace.java
@@ -1,6 +1,7 @@
 package alexiil.mc.mod.pipes.blocks;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import alexiil.mc.mod.pipes.container.ContainerTriggerFluidSpace;
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -11,8 +12,6 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 
 public class BlockTriggerFluidSpace extends BlockTriggerFluidInv {
 
@@ -31,12 +30,11 @@ public class BlockTriggerFluidSpace extends BlockTriggerFluidInv {
     ) {
         BlockEntity be = world.getBlockEntity(pos);
 
-        if (be instanceof TileTriggerFluidSpace) {
+        if (be instanceof TileTriggerFluidSpace tile) {
             if (!world.isClient) {
-                ContainerProviderRegistry.INSTANCE
-                    .openContainer(SimplePipeContainers.TRIGGER_FLUID_INV_SPACE, player, (buffer) -> {
-                        buffer.writeBlockPos(pos);
-                    });
+                player.openHandledScreen(new SimplePipeContainerFactory(getName(),
+                        (syncId, inv, player1) -> new ContainerTriggerFluidSpace(syncId, player1, tile),
+                        (player1, buf) -> buf.writeBlockPos(pos)));
             }
             return ActionResult.SUCCESS;
         }

--- a/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerInvContains.java
+++ b/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerInvContains.java
@@ -1,6 +1,7 @@
 package alexiil.mc.mod.pipes.blocks;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import alexiil.mc.mod.pipes.container.ContainerTriggerInvContains;
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -11,8 +12,6 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 
 public class BlockTriggerInvContains extends BlockTriggerItemInv {
 
@@ -31,12 +30,11 @@ public class BlockTriggerInvContains extends BlockTriggerItemInv {
     ) {
         BlockEntity be = world.getBlockEntity(pos);
 
-        if (be instanceof TileTriggerInvContains) {
+        if (be instanceof TileTriggerInvContains tile) {
             if (!world.isClient) {
-                ContainerProviderRegistry.INSTANCE
-                    .openContainer(SimplePipeContainers.TRIGGER_ITEM_INV_CONTAINS, player, (buffer) -> {
-                        buffer.writeBlockPos(pos);
-                    });
+                player.openHandledScreen(new SimplePipeContainerFactory(getName(),
+                        (syncId, inv, player1) -> new ContainerTriggerInvContains(syncId, player1, tile),
+                        (player1, buf) -> buf.writeBlockPos(pos)));
             }
             return ActionResult.SUCCESS;
         }

--- a/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerInvSpace.java
+++ b/src/main/java/alexiil/mc/mod/pipes/blocks/BlockTriggerInvSpace.java
@@ -1,6 +1,7 @@
 package alexiil.mc.mod.pipes.blocks;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import alexiil.mc.mod.pipes.container.ContainerTriggerInvSpace;
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -11,8 +12,6 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 
 public class BlockTriggerInvSpace extends BlockTriggerItemInv {
 
@@ -31,12 +30,11 @@ public class BlockTriggerInvSpace extends BlockTriggerItemInv {
     ) {
         BlockEntity be = world.getBlockEntity(pos);
 
-        if (be instanceof TileTriggerInvSpace) {
+        if (be instanceof TileTriggerInvSpace tile) {
             if (!world.isClient) {
-                ContainerProviderRegistry.INSTANCE
-                    .openContainer(SimplePipeContainers.TRIGGER_ITEM_INV_SPACE, player, (buffer) -> {
-                        buffer.writeBlockPos(pos);
-                    });
+                player.openHandledScreen(new SimplePipeContainerFactory(getName(),
+                        (syncId, inv, player1) -> new ContainerTriggerInvSpace(syncId, player, tile),
+                        (player1, buf) -> buf.writeBlockPos(pos)));
             }
             return ActionResult.SUCCESS;
         }

--- a/src/main/java/alexiil/mc/mod/pipes/client/model/ModelUtil.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/model/ModelUtil.java
@@ -8,7 +8,6 @@ package alexiil.mc.mod.pipes.client.model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
@@ -22,6 +21,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Direction.Axis;
 import net.minecraft.util.math.Direction.AxisDirection;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.util.shape.VoxelShape;
 
 import alexiil.mc.mod.pipes.util.SpriteUtil;
@@ -55,9 +55,9 @@ public class ModelUtil {
             return Collections.emptyList();
         }
         List<BakedQuad> quads = new ArrayList<>();
-        quads.addAll(model.getQuads(state, null, new Random(seed)));
+        quads.addAll(model.getQuads(state, null, Random.create(seed)));
         for (Direction dir : Direction.values()) {
-            quads.addAll(model.getQuads(state, dir, new Random(seed)));
+            quads.addAll(model.getQuads(state, dir, Random.create(seed)));
         }
         return quads;
     }

--- a/src/main/java/alexiil/mc/mod/pipes/client/model/MutableVertex.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/model/MutableVertex.java
@@ -18,7 +18,7 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.VertexFormatElement;
-import net.minecraft.client.render.VertexFormatElement.DataType;
+import net.minecraft.client.render.VertexFormatElement.ComponentType;
 import net.minecraft.client.render.VertexFormatElement.Type;
 import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.render.model.BakedQuad;
@@ -189,28 +189,28 @@ public class MutableVertex {
         for (VertexFormatElement elem : format.getElements()) {
             switch (elem.getType()) {
                 case POSITION: {
-                    assert elem.getDataType() == DataType.FLOAT;
+                    assert elem.getComponentType() == ComponentType.FLOAT;
                     position_x = Float.intBitsToFloat(data[o++]);
                     position_y = Float.intBitsToFloat(data[o++]);
                     position_z = Float.intBitsToFloat(data[o++]);
                     break;
                 }
                 case COLOR: {
-                    assert elem.getDataType() == DataType.UBYTE;
+                    assert elem.getComponentType() == ComponentType.UBYTE;
                     colouri(data[o++]);
                     break;
                 }
                 case NORMAL: {
-                    assert elem.getDataType() == DataType.BYTE;
+                    assert elem.getComponentType() == ComponentType.BYTE;
                     normali(data[o++]);
                     break;
                 }
                 case UV: {
-                    if (elem.getTextureIndex() == 0) {
+                    if (elem.getUvIndex() == 0) {
                         tex_u = Float.intBitsToFloat(data[o++]);
                         tex_v = Float.intBitsToFloat(data[o++]);
                         break;
-                    } else if (elem.getTextureIndex() == 1) {
+                    } else if (elem.getUvIndex() == 1) {
                         lighti(data[o++]);
                         break;
                     }
@@ -247,8 +247,8 @@ public class MutableVertex {
                         renderColour(bb);
                         break;
                     case UV:
-                        if (vfe.getTextureIndex() == 0) renderTex(bb);
-                        else if (vfe.getTextureIndex() == 1) renderLightMap(bb);
+                        if (vfe.getUvIndex() == 0) renderTex(bb);
+                        else if (vfe.getUvIndex() == 1) renderLightMap(bb);
                         break;
                     default:
                         break;

--- a/src/main/java/alexiil/mc/mod/pipes/client/model/PerspAwareModelBase.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/model/PerspAwareModelBase.java
@@ -6,7 +6,6 @@
 package alexiil.mc.mod.pipes.client.model;
 
 import java.util.List;
-import java.util.Random;
 
 import com.google.common.collect.ImmutableList;
 
@@ -20,6 +19,7 @@ import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.Direction;
 
 import alexiil.mc.mod.pipes.util.SpriteUtil;
+import net.minecraft.util.math.random.Random;
 
 public class PerspAwareModelBase implements BakedModel {
     private final ImmutableList<BakedQuad> quads;
@@ -32,7 +32,7 @@ public class PerspAwareModelBase implements BakedModel {
 
     public static List<BakedQuad> missingModel() {
         BakedModel model = ModelUtil.getMissingModel();
-        return model.getQuads(Blocks.AIR.getDefaultState(), null, new Random());
+        return model.getQuads(Blocks.AIR.getDefaultState(), null, Random.create());
     }
 
     @Override

--- a/src/main/java/alexiil/mc/mod/pipes/client/model/PipeBlockModel.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/model/PipeBlockModel.java
@@ -6,7 +6,6 @@
 package alexiil.mc.mod.pipes.client.model;
 
 import java.util.List;
-import java.util.Random;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -22,6 +21,7 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.BlockRenderView;
 
 import alexiil.mc.mod.pipes.blocks.BlockPipe;

--- a/src/main/java/alexiil/mc/mod/pipes/client/model/SimpleBakedModel.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/model/SimpleBakedModel.java
@@ -1,7 +1,6 @@
 package alexiil.mc.mod.pipes.client.model;
 
 import java.util.List;
-import java.util.Random;
 
 import com.google.common.collect.ImmutableList;
 
@@ -16,6 +15,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3f;
 import alexiil.mc.mod.pipes.mixin.impl.BakedQuadAccessor;
 import alexiil.mc.mod.pipes.util.SpriteUtil;
+import net.minecraft.util.math.random.Random;
 
 /** Provides a simple way of creating a {@link BakedModel} with just a list of quads. This provides some transforms to
  * use that make it simple to render item models with various different transforms. */

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenPipeDiamondItem.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenPipeDiamondItem.java
@@ -2,25 +2,26 @@ package alexiil.mc.mod.pipes.client.screen;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
-import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
 import alexiil.mc.mod.pipes.container.ContainerPipeDiamondItem;
 
 public class ScreenPipeDiamondItem extends HandledScreen<ContainerPipeDiamondItem> {
 
-    public static final ContainerScreenFactory<ContainerPipeDiamondItem> FACTORY = ScreenPipeDiamondItem::new;
+    public static final HandledScreens.Provider<ContainerPipeDiamondItem, ScreenPipeDiamondItem> FACTORY
+        = ScreenPipeDiamondItem::new;
 
     private static final Identifier GUI = new Identifier(SimplePipes.MODID, "textures/gui/filter.png");
 
-    public ScreenPipeDiamondItem(ContainerPipeDiamondItem container) {
-        super(container, container.player.getInventory(), SimplePipeBlocks.DIAMOND_PIPE_ITEMS.getName());
+    public ScreenPipeDiamondItem(ContainerPipeDiamondItem container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 222;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenPipeSorter.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenPipeSorter.java
@@ -2,25 +2,25 @@ package alexiil.mc.mod.pipes.client.screen;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
-import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
 import alexiil.mc.mod.pipes.container.ContainerPipeSorter;
 
 public class ScreenPipeSorter extends HandledScreen<ContainerPipeSorter> {
 
-    public static final ContainerScreenFactory<ContainerPipeSorter> FACTORY = ScreenPipeSorter::new;
+    public static final HandledScreens.Provider<ContainerPipeSorter, ScreenPipeSorter> FACTORY = ScreenPipeSorter::new;
 
     private static final Identifier GUI = new Identifier(SimplePipes.MODID, "textures/gui/filter.png");
 
-    public ScreenPipeSorter(ContainerPipeSorter container) {
-        super(container, container.player.getInventory(), SimplePipeBlocks.DIAMOND_PIPE_ITEMS.getName());
+    public ScreenPipeSorter(ContainerPipeSorter container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 222;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTank.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTank.java
@@ -5,18 +5,17 @@ import java.util.List;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
 import alexiil.mc.mod.pipes.container.ContainerTank;
-import alexiil.mc.mod.pipes.items.SimplePipeItems;
 import alexiil.mc.mod.pipes.util.FluidSmoother.FluidStackInterp;
 
 import alexiil.mc.lib.attributes.fluid.amount.FluidAmount;
@@ -26,12 +25,12 @@ import alexiil.mc.lib.attributes.fluid.volume.FluidVolume;
 
 public class ScreenTank extends HandledScreen<ContainerTank> {
 
-    public static final ContainerScreenFactory<ContainerTank> FACTORY = ScreenTank::new;
+    public static final HandledScreens.Provider<ContainerTank, ScreenTank> FACTORY = ScreenTank::new;
 
     private static final Identifier TANK_GUI = new Identifier(SimplePipes.MODID, "textures/gui/tank.png");
 
-    public ScreenTank(ContainerTank container) {
-        super(container, container.player.getInventory(), SimplePipeItems.TANK.getName());
+    public ScreenTank(ContainerTank container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 176;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerFluidInvContains.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerFluidInvContains.java
@@ -2,27 +2,27 @@ package alexiil.mc.mod.pipes.client.screen;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
-import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
 import alexiil.mc.mod.pipes.container.ContainerTriggerFluidContains;
 
 public class ScreenTriggerFluidInvContains extends HandledScreen<ContainerTriggerFluidContains> {
 
-    public static final ContainerScreenFactory<ContainerTriggerFluidContains> FACTORY
+    public static final HandledScreens.Provider<ContainerTriggerFluidContains, ScreenTriggerFluidInvContains> FACTORY
         = ScreenTriggerFluidInvContains::new;
 
     private static final Identifier TRIGGER_GUI
         = new Identifier(SimplePipes.MODID, "textures/gui/trigger_fluid_inv.png");
 
-    public ScreenTriggerFluidInvContains(ContainerTriggerFluidContains container) {
-        super(container, container.player.getInventory(), SimplePipeBlocks.TRIGGER_FLUID_INV_CONTAINS.getName());
+    public ScreenTriggerFluidInvContains(ContainerTriggerFluidContains container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 153;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerFluidInvSpace.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerFluidInvSpace.java
@@ -2,26 +2,27 @@ package alexiil.mc.mod.pipes.client.screen;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
-import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
 import alexiil.mc.mod.pipes.container.ContainerTriggerFluidSpace;
 
 public class ScreenTriggerFluidInvSpace extends HandledScreen<ContainerTriggerFluidSpace> {
 
-    public static final ContainerScreenFactory<ContainerTriggerFluidSpace> FACTORY = ScreenTriggerFluidInvSpace::new;
+    public static final HandledScreens.Provider<ContainerTriggerFluidSpace, ScreenTriggerFluidInvSpace> FACTORY
+        = ScreenTriggerFluidInvSpace::new;
 
     private static final Identifier TRIGGER_GUI
         = new Identifier(SimplePipes.MODID, "textures/gui/trigger_fluid_inv.png");
 
-    public ScreenTriggerFluidInvSpace(ContainerTriggerFluidSpace container) {
-        super(container, container.player.getInventory(), SimplePipeBlocks.TRIGGER_FLUID_INV_SPACE.getName());
+    public ScreenTriggerFluidInvSpace(ContainerTriggerFluidSpace container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 153;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerItemInvContains.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerItemInvContains.java
@@ -2,26 +2,27 @@ package alexiil.mc.mod.pipes.client.screen;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
-import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
 import alexiil.mc.mod.pipes.container.ContainerTriggerInvContains;
 
 public class ScreenTriggerItemInvContains extends HandledScreen<ContainerTriggerInvContains> {
 
-    public static final ContainerScreenFactory<ContainerTriggerInvContains> FACTORY = ScreenTriggerItemInvContains::new;
+    public static final HandledScreens.Provider<ContainerTriggerInvContains, ScreenTriggerItemInvContains> FACTORY
+        = ScreenTriggerItemInvContains::new;
 
     private static final Identifier TRIGGER_GUI
         = new Identifier(SimplePipes.MODID, "textures/gui/trigger_item_inv.png");
 
-    public ScreenTriggerItemInvContains(ContainerTriggerInvContains container) {
-        super(container, container.player.getInventory(), SimplePipeBlocks.TRIGGER_ITEM_INV_CONTAINS.getName());
+    public ScreenTriggerItemInvContains(ContainerTriggerInvContains container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 153;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerItemInvSpace.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/ScreenTriggerItemInvSpace.java
@@ -2,26 +2,27 @@ package alexiil.mc.mod.pipes.client.screen;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
-import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
 import alexiil.mc.mod.pipes.container.ContainerTriggerInvSpace;
 
 public class ScreenTriggerItemInvSpace extends HandledScreen<ContainerTriggerInvSpace> {
 
-    public static final ContainerScreenFactory<ContainerTriggerInvSpace> FACTORY = ScreenTriggerItemInvSpace::new;
+    public static final HandledScreens.Provider<ContainerTriggerInvSpace, ScreenTriggerItemInvSpace> FACTORY
+        = ScreenTriggerItemInvSpace::new;
 
     private static final Identifier TRIGGER_GUI
         = new Identifier(SimplePipes.MODID, "textures/gui/trigger_item_inv.png");
 
-    public ScreenTriggerItemInvSpace(ContainerTriggerInvSpace container) {
-        super(container, container.player.getInventory(), SimplePipeBlocks.TRIGGER_ITEM_INV_SPACE.getName());
+    public ScreenTriggerItemInvSpace(ContainerTriggerInvSpace container, PlayerInventory inv, Text title) {
+        super(container, inv, title);
         backgroundHeight = 153;
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/client/screen/SimplePipeScreens.java
+++ b/src/main/java/alexiil/mc/mod/pipes/client/screen/SimplePipeScreens.java
@@ -1,10 +1,8 @@
 package alexiil.mc.mod.pipes.client.screen;
 
-import net.fabricmc.fabric.api.client.screen.ContainerScreenFactory;
-import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
-
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.screen.ScreenHandler;
-import net.minecraft.util.Identifier;
+import net.minecraft.screen.ScreenHandlerType;
 
 import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 
@@ -21,7 +19,7 @@ public class SimplePipeScreens {
         register(SimplePipeContainers.TANK, ScreenTank.FACTORY);
     }
 
-    private static void register(Identifier id, ContainerScreenFactory<? extends ScreenHandler> factory) {
-        ScreenProviderRegistry.INSTANCE.registerFactory(id, factory);
+    private static <C extends ScreenHandler> void register(ScreenHandlerType<? extends C> type, HandledScreens.Provider<C, ?> factory) {
+        HandledScreens.register(type, factory);
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/compat/rei/REIPlugin.java
+++ b/src/main/java/alexiil/mc/mod/pipes/compat/rei/REIPlugin.java
@@ -7,19 +7,19 @@ import alexiil.mc.mod.pipes.items.SimplePipeItems;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.client.registry.entry.EntryRegistry;
-import me.shedaniel.rei.plugin.common.DefaultPlugin;
+import me.shedaniel.rei.plugin.common.BuiltinPlugin;
 
 public class REIPlugin implements REIClientPlugin {
 
     @Override
     public void registerDisplays(DisplayRegistry registry) {
-        registry.registerDisplayGenerator(DefaultPlugin.STONE_CUTTING, new FacadeDisplayGenerator());
+        registry.registerDisplayGenerator(BuiltinPlugin.STONE_CUTTING, new FacadeDisplayGenerator());
     }
 
     @Override
-    public void postRegister() {
-        EntryRegistry.getInstance().removeEntryIf(
-            stack -> (stack.getValue()instanceof ItemStack s) ? s.getItem() == SimplePipeItems.FACADE : false
+    public void registerEntries(EntryRegistry registry) {
+        registry.removeEntryIf(
+            stack -> stack.getValue() instanceof ItemStack s && s.getItem() == SimplePipeItems.FACADE
         );
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerPart.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerPart.java
@@ -2,6 +2,7 @@ package alexiil.mc.mod.pipes.container;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
@@ -10,13 +11,13 @@ import net.minecraft.world.World;
 import alexiil.mc.lib.multipart.api.AbstractPart;
 import alexiil.mc.lib.multipart.api.MultipartContainer;
 
-public class ContainerPart<P extends AbstractPart> extends ScreenHandler {
+public abstract class ContainerPart<P extends AbstractPart> extends ScreenHandler {
 
     public final PlayerEntity player;
     public final P part;
 
-    protected ContainerPart(int syncId, PlayerEntity player, P part) {
-        super(/* Custom containers don't use the ContainerType system */null, syncId);
+    protected ContainerPart(ScreenHandlerType<?> type, int syncId, PlayerEntity player, P part) {
+        super(type, syncId);
         this.player = player;
         this.part = part;
     }

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerPipeDiamondItem.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerPipeDiamondItem.java
@@ -19,7 +19,7 @@ public class ContainerPipeDiamondItem extends ContainerPart<PartSpPipe> {
         MultipartContainer container = MultipartContainer.ATTRIBUTE.getFirstOrNull(player.world, pos);
 
         if (container == null) {
-            return null;
+            throw new IllegalStateException("Attempted to open a diamond pipe screen where there is no diamond pipe!");
         }
 
         PartSpPipe pipe = container.getFirstPart(PartSpPipe.class);
@@ -27,7 +27,8 @@ public class ContainerPipeDiamondItem extends ContainerPart<PartSpPipe> {
         if (pipe.behaviour instanceof PipeSpBehaviourDiamond) {
             return new ContainerPipeDiamondItem(syncId, player, (PipeSpBehaviourDiamond) pipe.behaviour);
         }
-        return null;
+
+        throw new IllegalStateException("Attempted to open a diamond pipe screen where there is no diamond pipe!");
     };
 
     public final int startY = 18;

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerPipeDiamondItem.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerPipeDiamondItem.java
@@ -1,10 +1,8 @@
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 
@@ -15,7 +13,8 @@ import alexiil.mc.lib.multipart.api.MultipartContainer;
 
 public class ContainerPipeDiamondItem extends ContainerPart<PartSpPipe> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerPipeDiamondItem> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         MultipartContainer container = MultipartContainer.ATTRIBUTE.getFirstOrNull(player.world, pos);
 
@@ -35,7 +34,7 @@ public class ContainerPipeDiamondItem extends ContainerPart<PartSpPipe> {
     public final PipeSpBehaviourDiamond behaviour;
 
     public ContainerPipeDiamondItem(int syncId, PlayerEntity player, PipeSpBehaviourDiamond behaviour) {
-        super(syncId, player, behaviour.pipe);
+        super(SimplePipeContainers.PIPE_PART_DIAMOND_ITEM, syncId, player, behaviour.pipe);
         this.behaviour = behaviour;
 
         for (int y = 0; y < 6; y++) {

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerPipeSorter.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerPipeSorter.java
@@ -1,11 +1,9 @@
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 
@@ -13,7 +11,8 @@ import alexiil.mc.mod.pipes.blocks.TilePipeItemDiamond;
 
 public class ContainerPipeSorter extends ContainerTile<TilePipeItemDiamond> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerPipeSorter> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         BlockEntity be = player.world.getBlockEntity(pos);
         if (be instanceof TilePipeItemDiamond) {
@@ -25,7 +24,7 @@ public class ContainerPipeSorter extends ContainerTile<TilePipeItemDiamond> {
     public final int startY = 18;
 
     public ContainerPipeSorter(int syncId, PlayerEntity player, TilePipeItemDiamond tile) {
-        super(syncId, player, tile);
+        super(SimplePipeContainers.PIPE_DIAMOND_ITEM, syncId, player, tile);
         for (int y = 0; y < 6; y++) {
             for (int x = 0; x < 9; x++) {
                 addSlot(new Slot(tile.filterInv, x + y * 9, 8 + x * 18, startY + y * 18));

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTank.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTank.java
@@ -1,10 +1,8 @@
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 
@@ -18,7 +16,8 @@ import alexiil.mc.mod.pipes.part.PartTank;
 
 public class ContainerTank extends ContainerPart<PartTank> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerTank> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         MultipartContainer c = MultipartUtil.get(player.world, pos);
         if (c == null) {
@@ -32,8 +31,8 @@ public class ContainerTank extends ContainerPart<PartTank> {
 
     private boolean isInCall = false;
 
-    protected ContainerTank(int syncId, PlayerEntity player, PartTank tank) {
-        super(syncId, player, tank);
+    public ContainerTank(int syncId, PlayerEntity player, PartTank tank) {
+        super(SimplePipeContainers.TANK, syncId, player, tank);
         addPlayerInventory(94);
     }
 

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTank.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTank.java
@@ -21,12 +21,12 @@ public class ContainerTank extends ContainerPart<PartTank> {
         BlockPos pos = buffer.readBlockPos();
         MultipartContainer c = MultipartUtil.get(player.world, pos);
         if (c == null) {
-            return null;
+            throw new IllegalStateException("Attempted to open a tank screen where there is no tank!");
         }
         for (PartTank tank : c.getParts(PartTank.class)) {
             return new ContainerTank(syncId, player, tank);
         }
-        return null;
+        throw new IllegalStateException("Attempted to open a tank screen where there is no tank!");
     };
 
     private boolean isInCall = false;

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTile.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTile.java
@@ -3,17 +3,18 @@ package alexiil.mc.mod.pipes.container;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
-public class ContainerTile<T extends BlockEntity> extends ScreenHandler {
+public abstract class ContainerTile<T extends BlockEntity> extends ScreenHandler {
 
     public final PlayerEntity player;
     public final T tile;
 
-    protected ContainerTile(int syncId, PlayerEntity player, T tile) {
-        super(/* Custom containers don't use the ContainerType system */null, syncId);
+    protected ContainerTile(ScreenHandlerType<?> type, int syncId, PlayerEntity player, T tile) {
+        super(type, syncId);
         this.player = player;
         this.tile = tile;
     }

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerFluidContains.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerFluidContains.java
@@ -5,18 +5,18 @@
  */
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.screen.ScreenHandler;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 
 import alexiil.mc.mod.pipes.blocks.TileTriggerFluidContains;
 
 public class ContainerTriggerFluidContains extends ContainerTile<TileTriggerFluidContains> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerTriggerFluidContains> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         BlockEntity be = player.world.getBlockEntity(pos);
         if (be instanceof TileTriggerFluidContains) {
@@ -26,8 +26,13 @@ public class ContainerTriggerFluidContains extends ContainerTile<TileTriggerFlui
     };
 
     public ContainerTriggerFluidContains(int syncId, PlayerEntity player, TileTriggerFluidContains tile) {
-        super(syncId, player, tile);
+        super(SimplePipeContainers.TRIGGER_FLUID_INV_CONTAINS, syncId, player, tile);
         addPlayerInventory(71);
         // addSlot(new Slot(tile.filterInv, 0, 80, 26));
+    }
+
+    @Override
+    public ItemStack transferSlot(PlayerEntity player, int index) {
+        return ItemStack.EMPTY;
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerFluidSpace.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerFluidSpace.java
@@ -5,18 +5,18 @@
  */
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.screen.ScreenHandler;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 
 import alexiil.mc.mod.pipes.blocks.TileTriggerFluidSpace;
 
 public class ContainerTriggerFluidSpace extends ContainerTile<TileTriggerFluidSpace> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerTriggerFluidSpace> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         BlockEntity be = player.world.getBlockEntity(pos);
         if (be instanceof TileTriggerFluidSpace) {
@@ -26,8 +26,13 @@ public class ContainerTriggerFluidSpace extends ContainerTile<TileTriggerFluidSp
     };
 
     public ContainerTriggerFluidSpace(int syncId, PlayerEntity player, TileTriggerFluidSpace tile) {
-        super(syncId, player, tile);
+        super(SimplePipeContainers.TRIGGER_FLUID_INV_SPACE, syncId, player, tile);
         addPlayerInventory(71);
         // addSlot(new Slot(tile.filterInv, 0, 80, 26));
+    }
+
+    @Override
+    public ItemStack transferSlot(PlayerEntity player, int index) {
+        return ItemStack.EMPTY;
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerInvContains.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerInvContains.java
@@ -5,12 +5,10 @@
  */
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 
@@ -18,7 +16,8 @@ import alexiil.mc.mod.pipes.blocks.TileTriggerInvContains;
 
 public class ContainerTriggerInvContains extends ContainerTile<TileTriggerInvContains> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerTriggerInvContains> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         BlockEntity be = player.world.getBlockEntity(pos);
         if (be instanceof TileTriggerInvContains) {
@@ -28,7 +27,7 @@ public class ContainerTriggerInvContains extends ContainerTile<TileTriggerInvCon
     };
 
     public ContainerTriggerInvContains(int syncId, PlayerEntity player, TileTriggerInvContains tile) {
-        super(syncId, player, tile);
+        super(SimplePipeContainers.TRIGGER_ITEM_INV_CONTAINS, syncId, player, tile);
         addPlayerInventory(71);
         addSlot(new Slot(tile.filterInv, 0, 80, 26));
     }

--- a/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerInvSpace.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/ContainerTriggerInvSpace.java
@@ -5,11 +5,10 @@
  */
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.screen.ScreenHandler;
+import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.math.BlockPos;
 
@@ -17,7 +16,8 @@ import alexiil.mc.mod.pipes.blocks.TileTriggerInvSpace;
 
 public class ContainerTriggerInvSpace extends ContainerTile<TileTriggerInvSpace> {
 
-    public static final ContainerFactory<ScreenHandler> FACTORY = (syncId, id, player, buffer) -> {
+    public static final ExtendedScreenHandlerType.ExtendedFactory<ContainerTriggerInvSpace> FACTORY = (syncId, inv, buffer) -> {
+        PlayerEntity player = inv.player;
         BlockPos pos = buffer.readBlockPos();
         BlockEntity be = player.world.getBlockEntity(pos);
         if (be instanceof TileTriggerInvSpace) {
@@ -27,8 +27,13 @@ public class ContainerTriggerInvSpace extends ContainerTile<TileTriggerInvSpace>
     };
 
     public ContainerTriggerInvSpace(int syncId, PlayerEntity player, TileTriggerInvSpace tile) {
-        super(syncId, player, tile);
+        super(SimplePipeContainers.TRIGGER_ITEM_INV_SPACE, syncId, player, tile);
         addPlayerInventory(71);
         addSlot(new Slot(tile.filterInv, 0, 80, 26));
+    }
+
+    @Override
+    public ItemStack transferSlot(PlayerEntity player, int index) {
+        return ItemStack.EMPTY;
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/container/SimplePipeContainerFactory.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/SimplePipeContainerFactory.java
@@ -1,0 +1,49 @@
+package alexiil.mc.mod.pipes.container;
+
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+
+public class SimplePipeContainerFactory implements ExtendedScreenHandlerFactory {
+    private final OpeningDataWriter writer;
+    private final Text displayName;
+    private final ContainerCreator creator;
+
+    public SimplePipeContainerFactory(Text displayName, ContainerCreator creator, OpeningDataWriter writer) {
+        this.writer = writer;
+        this.displayName = displayName;
+        this.creator = creator;
+    }
+
+    @Override
+    public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+        writer.writeScreenOpeningData(player, buf);
+    }
+
+    @Override
+    public Text getDisplayName() {
+        return displayName;
+    }
+
+    @Nullable
+    @Override
+    public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
+        return creator.createMenu(syncId, inv, player);
+    }
+
+    @FunctionalInterface
+    public interface OpeningDataWriter {
+        void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf);
+    }
+
+    @FunctionalInterface
+    public interface ContainerCreator {
+        @Nullable
+        ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player);
+    }
+}

--- a/src/main/java/alexiil/mc/mod/pipes/container/SimplePipeContainers.java
+++ b/src/main/java/alexiil/mc/mod/pipes/container/SimplePipeContainers.java
@@ -5,38 +5,44 @@
  */
 package alexiil.mc.mod.pipes.container;
 
-import net.fabricmc.fabric.api.container.ContainerFactory;
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
-
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.Identifier;
 
 import alexiil.mc.mod.pipes.SimplePipes;
+import net.minecraft.util.registry.Registry;
 
 public class SimplePipeContainers {
-    public static final Identifier TRIGGER_ITEM_INV_SPACE = id("trigger_item_inv_space");
-    public static final Identifier TRIGGER_ITEM_INV_CONTAINS = id("trigger_item_inv_contains");
-    public static final Identifier TRIGGER_FLUID_INV_SPACE = id("trigger_fluid_inv_space");
-    public static final Identifier TRIGGER_FLUID_INV_CONTAINS = id("trigger_fluid_inv_contains");
-    public static final Identifier PIPE_DIAMOND_ITEM = id("pipe_diamond_item");
-    public static final Identifier PIPE_PART_DIAMOND_ITEM = id("pipe_part_diamond_item");
-    public static final Identifier TANK = id("tank");
+    public static final ScreenHandlerType<ContainerTriggerInvSpace> TRIGGER_ITEM_INV_SPACE
+        = new ExtendedScreenHandlerType<>(ContainerTriggerInvSpace.FACTORY);
+    public static final ScreenHandlerType<ContainerTriggerInvContains> TRIGGER_ITEM_INV_CONTAINS
+        = new ExtendedScreenHandlerType<>(ContainerTriggerInvContains.FACTORY);
+    public static final ScreenHandlerType<ContainerTriggerFluidSpace> TRIGGER_FLUID_INV_SPACE
+        = new ExtendedScreenHandlerType<>(ContainerTriggerFluidSpace.FACTORY);
+    public static final ScreenHandlerType<ContainerTriggerFluidContains> TRIGGER_FLUID_INV_CONTAINS
+        = new ExtendedScreenHandlerType<>(ContainerTriggerFluidContains.FACTORY);
+    public static final ScreenHandlerType<ContainerPipeSorter> PIPE_DIAMOND_ITEM
+        = new ExtendedScreenHandlerType<>(ContainerPipeSorter.FACTORY);
+    public static final ScreenHandlerType<ContainerPipeDiamondItem> PIPE_PART_DIAMOND_ITEM
+        = new ExtendedScreenHandlerType<>(ContainerPipeDiamondItem.FACTORY);
+    public static final ScreenHandlerType<ContainerTank> TANK = new ExtendedScreenHandlerType<>(ContainerTank.FACTORY);
 
     private static Identifier id(String name) {
         return new Identifier(SimplePipes.MODID, name);
     }
 
     public static void load() {
-        register(TRIGGER_ITEM_INV_SPACE, ContainerTriggerInvSpace.FACTORY);
-        register(TRIGGER_ITEM_INV_CONTAINS, ContainerTriggerInvContains.FACTORY);
-        register(TRIGGER_FLUID_INV_SPACE, ContainerTriggerFluidSpace.FACTORY);
-        register(TRIGGER_FLUID_INV_CONTAINS, ContainerTriggerFluidContains.FACTORY);
-        register(PIPE_DIAMOND_ITEM, ContainerPipeSorter.FACTORY);
-        register(PIPE_PART_DIAMOND_ITEM, ContainerPipeDiamondItem.FACTORY);
-        register(TANK, ContainerTank.FACTORY);
+        register(id("trigger_item_inv_space"), TRIGGER_ITEM_INV_SPACE);
+        register(id("trigger_item_inv_contains"), TRIGGER_ITEM_INV_CONTAINS);
+        register(id("trigger_fluid_inv_space"), TRIGGER_FLUID_INV_SPACE);
+        register(id("trigger_fluid_inv_contains"), TRIGGER_FLUID_INV_CONTAINS);
+        register(id("pipe_diamond_item"), PIPE_DIAMOND_ITEM);
+        register(id("pipe_part_diamond_item"), PIPE_PART_DIAMOND_ITEM);
+        register(id("tank"), TANK);
     }
 
-    private static void register(Identifier id, ContainerFactory<ScreenHandler> factory) {
-        ContainerProviderRegistry.INSTANCE.registerFactory(id, factory);
+    private static void register(Identifier id, ScreenHandlerType<? extends ScreenHandler> type) {
+        Registry.register(Registry.SCREEN_HANDLER, id, type);
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/items/BlockItemPipe.java
+++ b/src/main/java/alexiil/mc/mod/pipes/items/BlockItemPipe.java
@@ -11,7 +11,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsageContext;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.ActionResult;
 import net.minecraft.world.World;
 
@@ -58,8 +57,8 @@ public class BlockItemPipe extends BlockItem {
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
         super.appendTooltip(stack, world, tooltip, context);
         if (FabricLoader.getInstance().isModLoaded("pipe_vacuum_pump")) {
-            tooltip.add(new TranslatableText("block.simple_pipes.pipe_wooden_item.disabled_redstone.1"));
-            tooltip.add(new TranslatableText("block.simple_pipes.pipe_wooden_item.disabled_redstone.2"));
+            tooltip.add(Text.translatable("block.simple_pipes.pipe_wooden_item.disabled_redstone.1"));
+            tooltip.add(Text.translatable("block.simple_pipes.pipe_wooden_item.disabled_redstone.2"));
         }
     }
 }

--- a/src/main/java/alexiil/mc/mod/pipes/items/BlockItemPipe.java
+++ b/src/main/java/alexiil/mc/mod/pipes/items/BlockItemPipe.java
@@ -33,7 +33,7 @@ public class BlockItemPipe extends BlockItem {
 
         World w = context.getWorld();
         if (w.isClient) {
-            return ActionResult.PASS;
+            return ActionResult.SUCCESS;
         }
 
         PartOffer offer = getOffer(context);
@@ -44,7 +44,7 @@ public class BlockItemPipe extends BlockItem {
         offer.getHolder().getPart().onPlacedBy(context.getPlayer(), context.getHand());
         context.getStack().increment(-1);
         SoundUtil.playBlockPlace(w, offer.getHolder().getContainer().getMultipartPos());
-        return ActionResult.SUCCESS;
+        return ActionResult.CONSUME;
     }
 
     private PartOffer getOffer(ItemUsageContext context) {

--- a/src/main/java/alexiil/mc/mod/pipes/items/GhostPlacementPart.java
+++ b/src/main/java/alexiil/mc/mod/pipes/items/GhostPlacementPart.java
@@ -5,8 +5,6 @@
  */
 package alexiil.mc.mod.pipes.items;
 
-import java.util.Random;
-
 import javax.annotation.Nullable;
 
 import net.minecraft.client.MinecraftClient;
@@ -25,6 +23,7 @@ import alexiil.mc.lib.multipart.api.render.PartModelKey;
 import alexiil.mc.lib.multipart.impl.LibMultiPart;
 import alexiil.mc.lib.multipart.impl.client.model.SinglePartBakedModel;
 import alexiil.mc.mod.pipes.client.render.ItemPlacemenentGhostRenderer;
+import net.minecraft.util.math.random.Random;
 
 public abstract class GhostPlacementPart extends GhostPlacement {
 
@@ -65,7 +64,7 @@ public abstract class GhostPlacementPart extends GhostPlacement {
         matrices.push();
         matrices.translate(pos.getX(), pos.getY(), pos.getZ());
         blockRenderer.render(
-            mc.world, model, LibMultiPart.BLOCK.getDefaultState(), pos, matrices, buffer, true, new Random(), 0, -1
+            mc.world, model, LibMultiPart.BLOCK.getDefaultState(), pos, matrices, buffer, true, Random.create(), 0, -1
         );
         matrices.pop();
     }

--- a/src/main/java/alexiil/mc/mod/pipes/items/ItemFacade.java
+++ b/src/main/java/alexiil/mc/mod/pipes/items/ItemFacade.java
@@ -25,9 +25,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsageContext;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
@@ -180,11 +179,11 @@ public class ItemFacade extends Item implements IItemPlacmentGhost {
             key += "unknown_shape";
         }
         key += facade.shape.getSize().name().toLowerCase(Locale.ROOT);
-        return new TranslatableText(key, getFacadeStateDisplayName(facade.state.state));
+        return Text.translatable(key, getFacadeStateDisplayName(facade.state.state));
     }
 
-    public static TranslatableText getFacadeStateDisplayName(BlockState state) {
-        return new TranslatableText(state.getBlock().getTranslationKey());
+    public static MutableText getFacadeStateDisplayName(BlockState state) {
+        return Text.translatable(state.getBlock().getTranslationKey());
     }
 
     @Environment(EnvType.CLIENT)
@@ -193,12 +192,12 @@ public class ItemFacade extends Item implements IItemPlacmentGhost {
         FullFacade states = getStates(stack);
         if (flag.isAdvanced()) {
             Identifier blockId = Registry.BLOCK.getId(states.state.state.getBlock());
-            tooltip.add(new LiteralText(blockId.toString()));
+            tooltip.add(Text.of(blockId.toString()));
         }
         String propertiesStart = Formatting.GRAY + "" + Formatting.ITALIC;
         FacadeBlockStateInfo info = states.state;
         BlockUtil.getPropertiesStringMap(info.state, info.varyingProperties)
-            .forEach((name, value) -> tooltip.add(new LiteralText(propertiesStart + name + " = " + value)));
+            .forEach((name, value) -> tooltip.add(Text.of(propertiesStart + name + " = " + value)));
     }
 
     // Placement

--- a/src/main/java/alexiil/mc/mod/pipes/items/ItemFacade.java
+++ b/src/main/java/alexiil/mc/mod/pipes/items/ItemFacade.java
@@ -232,7 +232,7 @@ public class ItemFacade extends Item implements IItemPlacmentGhost {
     public ActionResult useOnBlock(ItemUsageContext ctx) {
         World w = ctx.getWorld();
         if (w.isClient) {
-            return ActionResult.PASS;
+            return ActionResult.SUCCESS;
         }
 
         PartOffer offer = offer(ctx);
@@ -241,7 +241,7 @@ public class ItemFacade extends Item implements IItemPlacmentGhost {
             offer.apply();
             ctx.getStack().increment(-1);
             SoundUtil.playBlockPlace(ctx.getWorld(), ctx.getBlockPos(), fullState.state.state);
-            return ActionResult.SUCCESS;
+            return ActionResult.CONSUME;
         }
         return ActionResult.FAIL;
     }

--- a/src/main/java/alexiil/mc/mod/pipes/items/ItemSimplePart.java
+++ b/src/main/java/alexiil/mc/mod/pipes/items/ItemSimplePart.java
@@ -38,7 +38,7 @@ public class ItemSimplePart extends Item implements IItemPlacmentGhost {
     public ActionResult useOnBlock(ItemUsageContext ctx) {
         World w = ctx.getWorld();
         if (w.isClient) {
-            return ActionResult.PASS;
+            return ActionResult.SUCCESS;
         }
 
         PartOffer offer = getOffer(ctx);
@@ -49,7 +49,7 @@ public class ItemSimplePart extends Item implements IItemPlacmentGhost {
         offer.getHolder().getPart().onPlacedBy(ctx.getPlayer(), ctx.getHand());
         ctx.getStack().increment(-1);
         SoundUtil.playBlockPlace(w, offer.getHolder().getContainer().getMultipartPos());
-        return ActionResult.SUCCESS;
+        return ActionResult.CONSUME;
     }
 
     private PartOffer getOffer(ItemUsageContext ctx) {

--- a/src/main/java/alexiil/mc/mod/pipes/part/PartTank.java
+++ b/src/main/java/alexiil/mc/mod/pipes/part/PartTank.java
@@ -2,8 +2,7 @@ package alexiil.mc.mod.pipes.part;
 
 import javax.annotation.Nullable;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
-
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
@@ -17,7 +16,7 @@ import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.World;
 
 import alexiil.mc.mod.pipes.client.model.part.TankPartModelKey;
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
+import alexiil.mc.mod.pipes.container.ContainerTank;
 import alexiil.mc.mod.pipes.items.SimplePipeItems;
 import alexiil.mc.mod.pipes.util.FluidSmoother;
 import alexiil.mc.mod.pipes.util.FluidSmoother.FluidStackInterp;
@@ -162,9 +161,9 @@ public class PartTank extends AbstractPart {
     public ActionResult onUse(PlayerEntity player, Hand hand, BlockHitResult hit) {
         if (player.getStackInHand(hand).isEmpty()) {
             if (!player.world.isClient) {
-                ContainerProviderRegistry.INSTANCE.openContainer(SimplePipeContainers.TANK, player, (buffer) -> {
-                    buffer.writeBlockPos(holder.getContainer().getMultipartPos());
-                });
+                player.openHandledScreen(new SimplePipeContainerFactory(SimplePipeItems.TANK.getName(),
+                        (syncId, inv, player1) -> new ContainerTank(syncId, player1, this),
+                        (player1, buf) -> buf.writeBlockPos(holder.getContainer().getMultipartPos())));
             }
             return ActionResult.SUCCESS;
         }

--- a/src/main/java/alexiil/mc/mod/pipes/part/PipeSpBehaviourDiamond.java
+++ b/src/main/java/alexiil/mc/mod/pipes/part/PipeSpBehaviourDiamond.java
@@ -4,8 +4,9 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
-
+import alexiil.mc.mod.pipes.blocks.SimplePipeBlocks;
+import alexiil.mc.mod.pipes.container.ContainerPipeDiamondItem;
+import alexiil.mc.mod.pipes.container.SimplePipeContainerFactory;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.ItemStack;
@@ -18,7 +19,6 @@ import net.minecraft.util.math.Direction;
 
 import alexiil.mc.mod.pipes.blocks.TilePipe;
 import alexiil.mc.mod.pipes.blocks.TilePipeItemDiamond;
-import alexiil.mc.mod.pipes.container.SimplePipeContainers;
 import alexiil.mc.mod.pipes.pipe.PartSpPipe;
 import alexiil.mc.mod.pipes.pipe.PipeSpBehaviour;
 import alexiil.mc.mod.pipes.pipe.TravellingItem;
@@ -113,10 +113,9 @@ public class PipeSpBehaviourDiamond extends PipeSpBehaviour {
     @Override
     public ActionResult onUse(PlayerEntity player, Hand hand, BlockHitResult hit) {
         if (!player.world.isClient) {
-            ContainerProviderRegistry.INSTANCE
-                .openContainer(SimplePipeContainers.PIPE_PART_DIAMOND_ITEM, player, (buffer) -> {
-                    buffer.writeBlockPos(pipe.getPipePos());
-                });
+            player.openHandledScreen(new SimplePipeContainerFactory(SimplePipeBlocks.DIAMOND_PIPE_ITEMS.getName(),
+                    (syncId, inv, player1) -> new ContainerPipeDiamondItem(syncId, player1, this),
+                    (player1, buf) -> buf.writeBlockPos(pipe.getPipePos())));
         }
         return ActionResult.SUCCESS;
     }

--- a/src/main/java/alexiil/mc/mod/pipes/util/RenderUtil.java
+++ b/src/main/java/alexiil/mc/mod/pipes/util/RenderUtil.java
@@ -1,11 +1,9 @@
 package alexiil.mc.mod.pipes.util;
 
 import javax.annotation.Nullable;
-import alexiil.mc.mod.pipes.util.RenderUtil.TessellatorQueue;
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 
-import net.fabricmc.fabric.api.client.render.ColorProviderRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,11 +8,11 @@
   "entrypoints": {
     "main": ["alexiil.mc.mod.pipes.SimplePipes"],
     "client": ["alexiil.mc.mod.pipes.SimplePipesClient"],
-    "rei_plugins": ["alexiil.mc.mod.pipes.compat.rei.REIPlugin"]
+    "rei_client": ["alexiil.mc.mod.pipes.compat.rei.REIPlugin"]
   },
   "depends": {
     "fabric": "*",
-    "minecraft": [ ">=1.18-rc.3 <1.19-" ],
+    "minecraft": [ ">=1.19- <1.20" ],
     "libblockattributes": "*",
     "libnetworkstack": "*",
     "libmultipart": "*"


### PR DESCRIPTION
# This PR
This PR updates SimplePipes to 1.19.

This PR also fixes some issues I encountered while testing the 1.19 port.

## Extra Fixed Issues

* Updated GUI FAPI usage.
* Fixed issues with parts causing a crash when placed if replacing another block like grass.